### PR TITLE
correcciones estilos.css

### DIFF
--- a/estilos.css
+++ b/estilos.css
@@ -104,7 +104,7 @@ h1 {
 	padding: 50px;
 	gap:70px;
 	align-items:center ;
-	max-width: 1100px;
+	max-width: 1100px; /* en realidad esta propiedad debería tenerla la p de esta sección y la sección en sí estar al 100% porque sino queda descentrado, te dejo una captura en la pull request */
 
 }
 
@@ -156,7 +156,7 @@ h3 {
 	padding: 30px;
 	justify-content:space-evenly;
 	background-color: #2d0d3f;
-	font-size: 20px;
+	font-size: 20px; /*esto no hace nada*/
 
 }
 
@@ -164,8 +164,8 @@ h3 {
 		display: flex;
 		Flex-direction: column;
 		gap:10px;
-		justify-content:baseline;
-		background-color: #2d0d3f;
+		justify-content:baseline; /* esto no funciona y salta como error*/
+		background-color: #2d0d3f; /* está de más */
 		font-size: 20px;
 		max-width: 400px;
 		
@@ -223,7 +223,7 @@ gap:50px;
 
 
 .cajatexto {
-display:flex;
+display:flex; /* esta parte no es necesario que tenga flexbox, pero si lo que te preocupa es que el título te quede marginado a la izquiera lo que te está causando un conflicto es que los h3 tienen text-align center, si establecés que el h3 de esta sección tenga otra alineación, y con esto también ahorrás 3 líneas de css que tiene este selector */
 align-items:flex-start;
 flex-direction: column;
 


### PR DESCRIPTION
**Esto va genial pero hay algunos ajustes que te dejo fotos:**

Capaz en tu compu no lo veas así pero en mi monitor que es más grande se termina viendo descentrado y hace ruido que quede lejos de los ojitos:
![image](https://github.com/user-attachments/assets/4c723bf6-2218-4d91-a078-8f44b9fe7c50)

El primer problema es que toda la sección tiene un max-width lo que hace que en realidad la caja esté así:
![image](https://github.com/user-attachments/assets/f90e0bd0-2985-40af-b9bc-2789a01e4b93)

Entiendo que es para que el texto no quede larguísimo, pero en este caso al que hay que aplicarle max-width debería ser al p y no a la sección entera, queda así:
![image](https://github.com/user-attachments/assets/433162e2-de33-4671-9707-eceb78a0cede)
![image](https://github.com/user-attachments/assets/93df69cf-ba90-4854-a1b8-0966b8a5ef30)


Y la otra cosa que me hace ruido de diseño es la siguiente:
![image](https://github.com/user-attachments/assets/fd36aeb1-9777-4de9-b77c-492ecee25711)
Las columnas quedan muy separadas a causa del space-evenly, y lo que me hace más ruido es que le pusiste un column-gap para separarlas que funcionaría mucho mejor.

Igual todo estos son detalles de diseño para mejorar pero en sí el tp está excelente 